### PR TITLE
Batch file for rasa core and action server

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ python3 -m venv ./dev
 source ./dev/bin/activate
 ```
 
+* Setup a dev virtual environment on your local machine (Windows)
+```
+python3 -m venv ./dev
+.\dev\Scripts\activate
+```
+
 * Install requirements
 ```bash
 pip install -r requirements.txt
@@ -64,6 +70,11 @@ rasa run actions --actions actions &
 Start rasa core and specify the custom connector.<br>
 ```
 rasa run -m models --debug --endpoints config/endpoints.yml --credentials config/credentials.yml
+```
+
+### Start RASA Action and Core Service (Windows) ###
+```
+call local_start.bat
 ```
 
 ### Using Machaao tunnel to expose PORT (Required) ###

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ rasa run -m models --debug --endpoints config/endpoints.yml --credentials config
 ```
 
 ### Start RASA Action and Core Service (Windows) ###
+Start rasa service and rasa core services in separate terminals.<br>
 ```
 call local_start.bat
 ```

--- a/local_start.bat
+++ b/local_start.bat
@@ -1,0 +1,5 @@
+:: Start rasa action server
+start cmd /k rasa run --debug actions --actions actions
+
+:: Start rasa server with models dir
+start cmd /k rasa run -m models --debug --endpoints config/endpoints.yml --credentials config/credentials-dev.yml

--- a/local_start.bat
+++ b/local_start.bat
@@ -2,4 +2,4 @@
 start cmd /k rasa run --debug actions --actions actions
 
 :: Start rasa server with models dir
-start cmd /k rasa run -m models --debug --endpoints config/endpoints.yml --credentials config/credentials-dev.yml
+start cmd /k rasa run -m models --debug --endpoints config/endpoints.yml --credentials config/credentials.yml

--- a/local_start.bat
+++ b/local_start.bat
@@ -1,5 +1,5 @@
 :: Start rasa action server
 start cmd /k rasa run --debug actions --actions actions
 
-:: Start rasa server with models dir
+:: Start rasa core server
 start cmd /k rasa run -m models --debug --endpoints config/endpoints.yml --credentials config/credentials.yml


### PR DESCRIPTION
### **Batch file for rasa servers**

A local_start.bat file that can used to run the bot locally.
After the installation of requirements, "call local_start.bat" command used for initializing the action and core rasa servers.